### PR TITLE
Center Around Mouse Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ To install: Place this .dll in the ...\Poly Bridge 2\BepInEx\plugins folder
 
 - Center Point: Gravity is centered at this point when "CenterPoint" is the gravity type
 
+- Center on Mouse: Gravity is  centered around where you mouse is when "CenterPoint" is the gravity type (Overrides "Center Point" setting)
+
 - Custom Shape Color: Controls wich shapes have gravity when "CenterShape(StaticPins)" is the gravity type (If blank all shapes have gravity)
 
 - Ignore Own Gravity: Custom shapes will ignore there own gravity if they have gravity


### PR DESCRIPTION
I added an option to center gravity around the mouse. It requires the gravity mode to be set to "Center Point". When it is active, it puts the camera into front view and disallows rotation of camera because it only functions when the camera is facing forward. While making this I noticed that the "follow camera" feature gets messed up if you rotate the camera when it is active so I also made the rotation of camera disabled when you are using that.